### PR TITLE
excluindo a classe abstrata Triangulo e criando a classe abstrata PoligonoRegular

### DIFF
--- a/src/br/edu/insper/desagil/geocalc/HexagonoRegular.java
+++ b/src/br/edu/insper/desagil/geocalc/HexagonoRegular.java
@@ -1,15 +1,9 @@
 package br.edu.insper.desagil.geocalc;
 
-public class HexagonoRegular extends Poligono {
-	private int lado;
+public class HexagonoRegular extends PoligonoRegular {
 
-	public HexagonoRegular(int lado) {
-		this.lado = lado;
-	}
-
-	@Override
-	public double perimetro() {
-		return 6 * this.lado;
+	public HexagonoRegular(int lado, int numeroLados) {
+		super(lado, numeroLados);
 	}
 
 	@Override
@@ -18,6 +12,6 @@ public class HexagonoRegular extends Poligono {
 
 		double altura = Math.sqrt(this.lado * this.lado - meio * meio);
 
-		return 6 * this.lado * altura / 2;
+		return numeroLados * this.lado * altura / 2;
 	}
 }

--- a/src/br/edu/insper/desagil/geocalc/PoligonoRegular.java
+++ b/src/br/edu/insper/desagil/geocalc/PoligonoRegular.java
@@ -1,0 +1,20 @@
+package br.edu.insper.desagil.geocalc;
+
+public abstract class PoligonoRegular extends Poligono {
+	public int lado;
+	public int numeroLados;
+
+
+	public PoligonoRegular(int lado, int numeroLados) {
+		super();
+		this.lado = lado;
+		this.numeroLados = numeroLados;
+	}
+
+	public double perimetro() {
+		return this.lado * this.numeroLados;
+	}
+
+	public abstract double area();
+
+}

--- a/src/br/edu/insper/desagil/geocalc/Triangulo.java
+++ b/src/br/edu/insper/desagil/geocalc/Triangulo.java
@@ -1,4 +1,0 @@
-package br.edu.insper.desagil.geocalc;
-
-public abstract class Triangulo extends Poligono {
-}

--- a/src/br/edu/insper/desagil/geocalc/TrianguloEquilatero.java
+++ b/src/br/edu/insper/desagil/geocalc/TrianguloEquilatero.java
@@ -1,15 +1,9 @@
 package br.edu.insper.desagil.geocalc;
 
-public class TrianguloEquilatero extends Triangulo {
-	private int lado;
+public class TrianguloEquilatero extends PoligonoRegular {
 
-	public TrianguloEquilatero(int lado) {
-		this.lado = lado;
-	}
-
-	@Override
-	public double perimetro() {
-		return 3 * this.lado;
+	public TrianguloEquilatero(int lado, int numeroLados) {
+		super(lado, numeroLados);
 	}
 
 	@Override

--- a/src/br/edu/insper/desagil/geocalc/TrianguloRetangulo.java
+++ b/src/br/edu/insper/desagil/geocalc/TrianguloRetangulo.java
@@ -1,6 +1,6 @@
 package br.edu.insper.desagil.geocalc;
 
-public class TrianguloRetangulo extends Triangulo {
+public class TrianguloRetangulo extends Poligono {
 	private int cateto1;
 	private int cateto2;
 

--- a/test/br/edu/insper/desagil/geocalc/HexagonoRegularTest.java
+++ b/test/br/edu/insper/desagil/geocalc/HexagonoRegularTest.java
@@ -9,7 +9,7 @@ class HexagonoRegularTest {
 
 	@Test
 	void test() {
-		Poligono poligono = new HexagonoRegular(5);
+		Poligono poligono = new HexagonoRegular(5, 6);
 		assertEquals(30.0, poligono.perimetro(), DELTA);
 		assertEquals(64.95, poligono.area(), DELTA);
 	}

--- a/test/br/edu/insper/desagil/geocalc/TrianguloEquilateroTest.java
+++ b/test/br/edu/insper/desagil/geocalc/TrianguloEquilateroTest.java
@@ -9,7 +9,7 @@ class TrianguloEquilateroTest {
 
 	@Test
 	void test() {
-		Poligono poligono = new TrianguloEquilatero(5);
+		Poligono poligono = new TrianguloEquilatero(5, 3);
 		assertEquals(15.0, poligono.perimetro(), DELTA);
 		assertEquals(10.83, poligono.area(), DELTA);
 	}


### PR DESCRIPTION
Como a classe TrianguloRetangulo seguia uma lógica mais parecida com a da classe HexagonoRegular (uma vez que ambos tratam de polígonos cujos lados são todos iguais) do que com a da classe TrianguloEquilatero, eu apaguei a classe Triangulo, tornando TrianguloEquilatero uma subclasse de Poligono, e criei a classe abstrata PoligonoRegular, também subclasse de Poligono, tornando as classes HexagonoRegular e TrianguloEquilatero subclasses da nova classe. Para melhorar a coesão do código, eu fiz com que a função perimetro fosse calculada diretamente na classe PoligonoRegular, porém para isso adicionei uma nova constante necessária a todas as subclasses de PoligonoRegular, que é o número de lados, necessário para calcular o perímetro, alterando os testes para que continuassem a funcionar.