### PR TITLE
Delta

### DIFF
--- a/src/br/edu/insper/desagil/geocalc/HexagonoRegular.java
+++ b/src/br/edu/insper/desagil/geocalc/HexagonoRegular.java
@@ -7,17 +7,12 @@ public class HexagonoRegular extends Poligono {
 		this.lado = lado;
 	}
 
-	@Override
 	public double perimetro() {
-		return 6 * this.lado;
+		return 2 * super.perimetro();
 	}
 
-	@Override
 	public double area() {
-		double meio = this.lado / 2.0;
-
-		double altura = Math.sqrt(this.lado * this.lado - meio * meio);
-
-		return 6 * this.lado * altura / 2;
+		return 6 * super.area();
 	}
+
 }

--- a/src/br/edu/insper/desagil/geocalc/Poligono.java
+++ b/src/br/edu/insper/desagil/geocalc/Poligono.java
@@ -1,7 +1,19 @@
 package br.edu.insper.desagil.geocalc;
 
-public abstract class Poligono {
-	public abstract double perimetro();
+public class Poligono {
+	private int lado;
+	
+	public double perimetro() {
+		return 3 * this.lado;
+	};
 
-	public abstract double area();
-}
+	public double area() {
+		double meio = this.lado / 2.0;
+
+		double altura = Math.sqrt(this.lado * this.lado - meio * meio);
+
+		return this.lado * altura / 2;
+	};
+	
+};
+	

--- a/src/br/edu/insper/desagil/geocalc/Triangulo.java
+++ b/src/br/edu/insper/desagil/geocalc/Triangulo.java
@@ -1,4 +1,5 @@
 package br.edu.insper.desagil.geocalc;
 
 public abstract class Triangulo extends Poligono {
+
 }

--- a/src/br/edu/insper/desagil/geocalc/TrianguloEquilatero.java
+++ b/src/br/edu/insper/desagil/geocalc/TrianguloEquilatero.java
@@ -7,17 +7,11 @@ public class TrianguloEquilatero extends Triangulo {
 		this.lado = lado;
 	}
 
-	@Override
 	public double perimetro() {
-		return 3 * this.lado;
+		return super.perimetro();
 	}
 
-	@Override
 	public double area() {
-		double meio = this.lado / 2.0;
-
-		double altura = Math.sqrt(this.lado * this.lado - meio * meio);
-
-		return this.lado * altura / 2;
+		return super.area();
 	}
 }

--- a/src/br/edu/insper/desagil/geocalc/TrianguloRetangulo.java
+++ b/src/br/edu/insper/desagil/geocalc/TrianguloRetangulo.java
@@ -9,13 +9,11 @@ public class TrianguloRetangulo extends Triangulo {
 		this.cateto2 = cateto2;
 	}
 
-	@Override
 	public double perimetro() {
 		double hipotenusa = Math.sqrt(this.cateto1 * this.cateto1 + this.cateto2 * this.cateto2);
 		return hipotenusa + this.cateto1 + this.cateto2;
 	}
 
-	@Override
 	public double area() {
 		return this.cateto1 * this.cateto2 / 2;
 	}


### PR DESCRIPTION
Como o cálculo da área do hexágono regular e do triângulo equilátero é muito parecido, é possível fazer um reutilizar o outro para evitar repetição de código. Como ambos são polímeros, é possível juntar o calculo de ambos no mesmo método.

(Não consegui fazer o método pegar o valor do lado sem mexer nos testes)